### PR TITLE
Use Docker to build on xenial.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,18 +9,14 @@ env:
   global:
     - MAKEFLAGS=-j5
     - OMP_NUM_THREADS=4
-
-matrix:
-  include:
-    - env:
-      - CXX=g++
-    - env:
-      - CXX=clang++
+  matrix:
+    - CXX=g++
+    - CXX=clang++
 
 before_install:
   - lscpu
   - sudo docker pull ubuntu:16.04
-  - sudo docker run -w /root --name test -d ubuntu:16.04 sleep infinity
+  - sudo docker run -w /root --name test -d -e CXX=${CXX} -e MAKEFLAGS=${MAKEFLAGS} -e OMP_NUM_THREADS=${OMP_NUM_THREADS} ubuntu:16.04 sleep infinity
   - sudo docker cp . test:/root/polatory
 
   - sudo docker exec test apt-get update -qq

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,49 +15,49 @@ env:
 
 before_install:
   - lscpu
-  - sudo docker pull ubuntu:16.04
-  - sudo docker run -w /root --name test -d -e CXX=${CXX} -e MAKEFLAGS=${MAKEFLAGS} -e OMP_NUM_THREADS=${OMP_NUM_THREADS} ubuntu:16.04 sleep infinity
-  - sudo docker cp . test:/root/polatory
+  - docker pull ubuntu:16.04
+  - docker run -w /root --name test -d -e CXX=${CXX} -e MAKEFLAGS=${MAKEFLAGS} -e OMP_NUM_THREADS=${OMP_NUM_THREADS} ubuntu:16.04 sleep infinity
+  - docker cp . test:/root/polatory
 
-  - sudo docker exec test apt-get update -qq
-  - sudo docker exec test apt-get install -qq apt-transport-https cmake git python wget
+  - docker exec test apt-get update -qq
+  - docker exec test apt-get install -qq apt-transport-https cmake git python wget
 
-  - sudo docker exec test sh -c 'wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB  -O - | apt-key add -'
-  - sudo docker exec test sh -c 'echo deb https://apt.repos.intel.com/mkl all main > /etc/apt/sources.list.d/intel-mkl.list'
-  - sudo docker exec test apt-get update -qq
+  - docker exec test sh -c 'wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB  -O - | apt-key add -'
+  - docker exec test sh -c 'echo deb https://apt.repos.intel.com/mkl all main > /etc/apt/sources.list.d/intel-mkl.list'
+  - docker exec test apt-get update -qq
 
 install:
 # Intel OpenMP (for building with Clang)
   - if [ "$CXX" == "clang++" ]; then
-      sudo docker exec test apt-get install -qq clang libiomp-dev;
+      docker exec test apt-get install -qq clang libiomp-dev;
     fi
 # Intel MKL
-  - sudo docker exec test apt-get install -qq intel-mkl-64bit-2018.1-038
+  - docker exec test apt-get install -qq intel-mkl-64bit-2018.1-038
 # Eigen
-  - sudo docker exec test apt-get install -qq libeigen3-dev
+  - docker exec test apt-get install -qq libeigen3-dev
 # Google Test
-  - sudo docker exec test apt-get install -qq libgtest-dev
-  - sudo docker exec test sh -c 'mkdir gtest-build && cd gtest-build && cmake /usr/src/gtest/ && make && cp *.a /usr/local/lib/'
+  - docker exec test apt-get install -qq libgtest-dev
+  - docker exec test sh -c 'mkdir gtest-build && cd gtest-build && cmake /usr/src/gtest/ && make && cp *.a /usr/local/lib/'
 # Ceres Solver
-  - sudo docker exec test apt-get install -qq libgoogle-glog-dev
-  - sudo docker exec test git clone --depth=1 https://ceres-solver.googlesource.com/ceres-solver
-  - sudo docker exec test sh -c 'cd ceres-solver && mkdir build && cd build && cmake .. -DBUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF -DCMAKE_LIBRARY_PATH=/opt/intel/mkl/lib/intel64 -DCXSPARSE=OFF -DEIGENSPARSE=OFF -DGFLAGS=OFF -DSCHUR_SPECIALIZATIONS=OFF -DSUITESPARSE=OFF && make && make install'
+  - docker exec test apt-get install -qq libgoogle-glog-dev
+  - docker exec test git clone --depth=1 https://ceres-solver.googlesource.com/ceres-solver
+  - docker exec test sh -c 'cd ceres-solver && mkdir build && cd build && cmake .. -DBUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF -DCMAKE_LIBRARY_PATH=/opt/intel/mkl/lib/intel64 -DCXSPARSE=OFF -DEIGENSPARSE=OFF -DGFLAGS=OFF -DSCHUR_SPECIALIZATIONS=OFF -DSUITESPARSE=OFF && make && make install'
 # FLANN
-  - sudo docker exec test apt-get install -qq libflann-dev
+  - docker exec test apt-get install -qq libflann-dev
 # Boost
-  - sudo docker exec test wget -q https://dl.bintray.com/boostorg/release/1.65.1/source/boost_1_65_1.tar.bz2
-  - sudo docker exec test tar xfj boost_1_65_1.tar.bz2
-  - sudo docker exec test sh -c 'cd boost_1_65_1 && ./bootstrap.sh && ./b2 link=shared --with-filesystem --with-program_options --with-serialization --with-system install -d0 -j4 --prefix=.'
+  - docker exec test wget -q https://dl.bintray.com/boostorg/release/1.65.1/source/boost_1_65_1.tar.bz2
+  - docker exec test tar xfj boost_1_65_1.tar.bz2
+  - docker exec test sh -c 'cd boost_1_65_1 && ./bootstrap.sh && ./b2 link=shared --with-filesystem --with-program_options --with-serialization --with-system install -d0 -j5 --prefix=.'
 
 before_script:
-  - sudo docker exec test sh -c 'cd polatory && mkdir build'
+  - docker exec test sh -c 'cd polatory && mkdir build'
 
 script:
-  - sudo docker exec test sh -c 'cd polatory/build && cmake .. -DBOOST_ROOT=~/boost_1_65_1 -DCMAKE_BUILD_TYPE=Release'
-  - sudo docker exec test sh -c 'cd polatory/build && make'
-  - sudo docker exec test sh -c 'cd polatory/build && ctest -VV'
-  - sudo docker exec test sh -c 'cd polatory && tools/inspection/inspect'
-  - sudo docker exec test sh -c 'cd polatory/build && make install'
+  - docker exec test sh -c 'cd polatory/build && cmake .. -DBOOST_ROOT=~/boost_1_65_1 -DCMAKE_BUILD_TYPE=Release'
+  - docker exec test sh -c 'cd polatory/build && make'
+  - docker exec test sh -c 'cd polatory/build && ctest -VV'
+  - docker exec test sh -c 'cd polatory && tools/inspection/inspect'
+  - docker exec test sh -c 'cd polatory/build && make install'
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,67 +1,67 @@
-language: cpp
 sudo: required
-dist: xenial
+dist: trusty
+language: cpp
+
+services:
+  - docker
 
 env:
   global:
     - MAKEFLAGS=-j5
     - OMP_NUM_THREADS=4
 
-compiler:
-  - gcc
-  - clang
+matrix:
+  include:
+    - env:
+      - CXX=g++
+    - env:
+      - CXX=clang++
 
 before_install:
   - lscpu
-  - curl https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB | sudo apt-key add -
-  - sudo sh -c 'echo deb https://apt.repos.intel.com/mkl all main > /etc/apt/sources.list.d/intel-mkl.list'
-  - sudo apt-get update -qq
+  - sudo docker pull ubuntu:16.04
+  - sudo docker run -w /root --name test -d ubuntu:16.04 sleep infinity
+  - sudo docker cp . test:/root/polatory
+
+  - sudo docker exec test apt-get update -qq
+  - sudo docker exec test apt-get install -qq apt-transport-https cmake git python wget
+
+  - sudo docker exec test sh -c 'wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB  -O - | apt-key add -'
+  - sudo docker exec test sh -c 'echo deb https://apt.repos.intel.com/mkl all main > /etc/apt/sources.list.d/intel-mkl.list'
+  - sudo docker exec test apt-get update -qq
 
 install:
 # Intel OpenMP (for building with Clang)
   - if [ "$CXX" == "clang++" ]; then
-      sudo apt-get install -y libiomp-dev;
+      sudo docker exec test apt-get install -qq clang libiomp-dev;
     fi
 # Intel MKL
-  - sudo apt-get install -y intel-mkl-64bit-2018.1-038
+  - sudo docker exec test apt-get install -qq intel-mkl-64bit-2018.1-038
 # Eigen
-  - sudo apt-get install -y libeigen3-dev
+  - sudo docker exec test apt-get install -qq libeigen3-dev
 # Google Test
-  - sudo apt-get install -y libgtest-dev
-  - cd
-  - mkdir gtest-build; cd gtest-build/
-  - cmake /usr/src/gtest/
-  - make
-  - sudo cp *.a /usr/local/lib/
+  - sudo docker exec test apt-get install -qq libgtest-dev
+  - sudo docker exec test sh -c 'mkdir gtest-build && cd gtest-build && cmake /usr/src/gtest/ && make && cp *.a /usr/local/lib/'
 # Ceres Solver
-  - sudo apt-get install -y libgoogle-glog-dev
-  - cd
-  - git clone --depth=1 https://ceres-solver.googlesource.com/ceres-solver
-  - cd ceres-solver
-  - mkdir build; cd build/
-  - cmake .. -DBUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF -DCMAKE_LIBRARY_PATH=/opt/intel/mkl/lib/intel64 -DCXSPARSE=OFF -DEIGENSPARSE=OFF -DGFLAGS=OFF -DSCHUR_SPECIALIZATIONS=OFF -DSUITESPARSE=OFF
-  - make
-  - sudo make install
+  - sudo docker exec test apt-get install -qq libgoogle-glog-dev
+  - sudo docker exec test git clone --depth=1 https://ceres-solver.googlesource.com/ceres-solver
+  - sudo docker exec test sh -c 'cd ceres-solver && mkdir build && cd build && cmake .. -DBUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF -DCMAKE_LIBRARY_PATH=/opt/intel/mkl/lib/intel64 -DCXSPARSE=OFF -DEIGENSPARSE=OFF -DGFLAGS=OFF -DSCHUR_SPECIALIZATIONS=OFF -DSUITESPARSE=OFF && make && make install'
 # FLANN
-  - sudo apt-get install -y libflann-dev
+  - sudo docker exec test apt-get install -qq libflann-dev
 # Boost
-  - cd
-  - wget https://dl.bintray.com/boostorg/release/1.65.1/source/boost_1_65_1.tar.bz2
-  - tar xfj boost_1_65_1.tar.bz2
-  - cd boost_1_65_1
-  - ./bootstrap.sh
-  - ./b2 link=shared --with-filesystem --with-program_options --with-serialization --with-system install -d0 -j4 --prefix=.
-
-before_script:
-  - cd $TRAVIS_BUILD_DIR
-  - mkdir build && cd build
+  - sudo docker exec test wget -q https://dl.bintray.com/boostorg/release/1.65.1/source/boost_1_65_1.tar.bz2
+  - sudo docker exec test tar xfj boost_1_65_1.tar.bz2
+  - sudo docker exec test sh -c 'cd boost_1_65_1 && ./bootstrap.sh && ./b2 link=shared --with-filesystem --with-program_options --with-serialization --with-system install -d0 -j4 --prefix=.'
 
 script:
-  - cmake .. -DBOOST_ROOT=~/boost_1_65_1 -DCMAKE_BUILD_TYPE=Release
-  - make
-  - ctest -VV
-  - $TRAVIS_BUILD_DIR/tools/inspection/inspect
-  - sudo make install
+  - sudo docker exec test sh -c 'cd polatory && mkdir build'
+
+script:
+  - sudo docker exec test sh -c 'cd polatory/build && cmake .. -DBOOST_ROOT=~/boost_1_65_1 -DCMAKE_BUILD_TYPE=Release'
+  - sudo docker exec test sh -c 'cd polatory/build && make'
+  - sudo docker exec test sh -c 'cd polatory/build && ctest -VV'
+  - sudo docker exec test sh -c 'cd polatory && tools/inspection/inspect'
+  - sudo docker exec test sh -c 'cd polatory/build && make install'
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ install:
   - sudo docker exec test tar xfj boost_1_65_1.tar.bz2
   - sudo docker exec test sh -c 'cd boost_1_65_1 && ./bootstrap.sh && ./b2 link=shared --with-filesystem --with-program_options --with-serialization --with-system install -d0 -j4 --prefix=.'
 
-script:
+before_script:
   - sudo docker exec test sh -c 'cd polatory && mkdir build'
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: required
 dist: trusty
-language: cpp
+language: minimal
 
 services:
   - docker


### PR DESCRIPTION
As [xenial support](https://github.com/travis-ci/travis-ci/issues/5821) is still experimental and it seems to have a few issues (https://github.com/travis-ci/travis-cookbooks/issues/952), we should use Docker to build polatory on that platform.