### PR TITLE
Refactor CMake scripts.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,15 +15,23 @@ matrix:
     - env:
       - CXX=g++
       - UBUNTU_VERSION=16.04
+      - CMAKE=/root/cmake-3.9.6-Linux-x86_64/bin/cmake
+      - CTEST=/root/cmake-3.9.6-Linux-x86_64/bin/ctest
     - env:
       - CXX=clang++
       - UBUNTU_VERSION=16.04
+      - CMAKE=/root/cmake-3.9.6-Linux-x86_64/bin/cmake
+      - CTEST=/root/cmake-3.9.6-Linux-x86_64/bin/ctest
     - env:
       - CXX=g++
       - UBUNTU_VERSION=18.04
+      - CMAKE=cmake
+      - CTEST=ctest
     - env:
       - CXX=clang++
       - UBUNTU_VERSION=18.04
+      - CMAKE=cmake
+      - CTEST=ctest
 
 cache:
   directories:
@@ -35,10 +43,15 @@ before_install:
   - docker cp $TRAVIS_BUILD_DIR test:/root
 
   - docker exec test apt-get update -qq
-  - docker exec test apt-get install -qq apt-transport-https cmake git gnupg lsb-release python wget
-
-  - docker exec test sh -c 'wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB -O - | apt-key add -'
-  - docker exec test sh -c 'echo deb https://apt.repos.intel.com/mkl all main > /etc/apt/sources.list.d/intel-mkl.list'
+  - docker exec test apt-get install -qq apt-transport-https git gnupg lsb-release ninja-build python wget
+  - if [ "$UBUNTU_VERSION"  == "16.04" ]; then
+      docker exec test wget -nv https://cmake.org/files/v3.9/cmake-3.9.6-Linux-x86_64.tar.gz;
+      docker exec test tar xzf cmake-3.9.6-Linux-x86_64.tar.gz;
+    else
+      docker exec test apt-get install -qq cmake;
+    fi
+  - docker exec test sh -c "wget -nv https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB -O - | apt-key add -"
+  - docker exec test sh -c "echo deb https://apt.repos.intel.com/mkl all main > /etc/apt/sources.list.d/intel-mkl.list"
   - docker exec test apt-get update -qq
 
 install:
@@ -51,37 +64,39 @@ install:
 # Eigen
   - docker exec test apt-get install -qq libeigen3-dev
 # Google Test
-  - docker exec test apt-get install -qq libgtest-dev
-  - docker exec test sh -c 'mkdir gtest-build && cd gtest-build && cmake /usr/src/gtest/ && make && cp *.a /usr/local/lib/'
+  - docker exec test git clone --depth=1 https://github.com/google/googletest.git
+  - docker exec test sh -c "cd googletest && mkdir build && cd build && $CMAKE .. -GNinja && ninja && ninja install"
 # Ceres Solver
   - docker exec test apt-get install -qq libgoogle-glog-dev;
   - if [ -n "$(ls $HOME/ceres-solver)" ]; then
       docker cp $HOME/ceres-solver test:/root;
-      docker exec test sh -c 'cd ceres-solver/build && make install';
+      docker exec test sh -c "cd ceres-solver/build && ninja install";
     else
       docker exec test git clone --depth=1 https://ceres-solver.googlesource.com/ceres-solver;
-      docker exec test sh -c 'cd ceres-solver && mkdir build && cd build && cmake .. -DBUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF -DCMAKE_LIBRARY_PATH=/opt/intel/mkl/lib/intel64 -DCXSPARSE=OFF -DEIGENSPARSE=OFF -DGFLAGS=OFF -DSCHUR_SPECIALIZATIONS=OFF -DSUITESPARSE=OFF && make && make install';
+      docker exec test sh -c "cd ceres-solver && mkdir build && cd build && $CMAKE .. -GNinja -DBUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF -DCMAKE_LIBRARY_PATH=/opt/intel/mkl/lib/intel64 -DCXSPARSE=OFF -DEIGENSPARSE=OFF -DGFLAGS=OFF -DSCHUR_SPECIALIZATIONS=OFF -DSUITESPARSE=OFF && ninja && ninja install";
       docker cp test:/root/ceres-solver $HOME;
     fi
 # FLANN
   - docker exec test apt-get install -qq libflann-dev
 # Boost
-  - docker exec test wget -q https://dl.bintray.com/boostorg/release/1.67.0/source/boost_1_67_0.tar.bz2
-  - docker exec test tar xfj boost_1_67_0.tar.bz2
-  - docker exec test sh -c 'cd boost_1_67_0 && ./bootstrap.sh && ./b2 link=shared --with-filesystem --with-program_options --with-serialization --with-system install -d0 -j5 --prefix=.'
+  - docker exec test wget -nv https://dl.bintray.com/boostorg/release/1.67.0/source/boost_1_67_0.tar.bz2
+  - docker exec test tar xjf boost_1_67_0.tar.bz2
+  - docker exec test sh -c "cd boost_1_67_0 && ./bootstrap.sh && ./b2 link=shared --with-filesystem --with-program_options --with-serialization --with-system install -d0 -j5 --prefix=."
 
 before_script:
   - lscpu
   - docker exec test lsb_release -a
-  - docker exec test ${CXX} --version
-  - docker exec test sh -c 'cd polatory && mkdir build'
+  - docker exec test $CMAKE --version
+  - docker exec test ninja --version
+  - docker exec test $CXX --version
+  - docker exec test sh -c "cd polatory && mkdir build"
 
 script:
-  - docker exec test sh -c 'cd polatory/build && cmake .. -DBOOST_ROOT=~/boost_1_67_0 -DCMAKE_BUILD_TYPE=Release'
-  - docker exec test sh -c 'cd polatory/build && make'
-  - docker exec test sh -c 'cd polatory/build && ctest -VV'
-  - docker exec test sh -c 'cd polatory && tools/inspection/inspect'
-  - docker exec test sh -c 'cd polatory/build && make install'
+  - docker exec test sh -c "cd polatory/build && $CMAKE .. -GNinja -DBOOST_ROOT=~/boost_1_67_0 -DCMAKE_BUILD_TYPE=Release"
+  - docker exec test sh -c "cd polatory/build && ninja"
+  - docker exec test sh -c "cd polatory/build && $CTEST -VV"
+  - docker exec test sh -c "cd polatory && tools/inspection/inspect"
+  - docker exec test sh -c "cd polatory/build && ninja install"
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,7 +92,7 @@ before_script:
   - docker exec test sh -c "cd polatory && mkdir build"
 
 script:
-  - docker exec test sh -c "cd polatory/build && $CMAKE .. -GNinja -DBOOST_ROOT=~/boost_1_67_0 -DCMAKE_BUILD_TYPE=Release"
+  - docker exec test sh -c "cd polatory/build && $CMAKE .. -GNinja -DBOOST_ROOT=~/boost_1_67_0"
   - docker exec test sh -c "cd polatory/build && ninja"
   - docker exec test sh -c "cd polatory/build && $CTEST -VV"
   - docker exec test sh -c "cd polatory && tools/inspection/inspect"

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,15 +50,14 @@ before_install:
     else
       docker exec test apt-get install -qq cmake;
     fi
+  - if [ "$CXX" == "clang++" ]; then
+      docker exec test apt-get install -qq clang libomp-dev;
+    fi
   - docker exec test sh -c "wget -nv https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB -O - | apt-key add -"
   - docker exec test sh -c "echo deb https://apt.repos.intel.com/mkl all main > /etc/apt/sources.list.d/intel-mkl.list"
   - docker exec test apt-get update -qq
 
 install:
-  # Intel OpenMP (for building with Clang)
-  - if [ "$CXX" == "clang++" ]; then
-      docker exec test apt-get install -qq clang libiomp-dev;
-    fi
   # Intel MKL
   - docker exec test apt-get install -qq intel-mkl-64bit-2018.3-051
   # Eigen

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,30 +55,31 @@ before_install:
   - docker exec test apt-get update -qq
 
 install:
-# Intel OpenMP (for building with Clang)
+  # Intel OpenMP (for building with Clang)
   - if [ "$CXX" == "clang++" ]; then
       docker exec test apt-get install -qq clang libiomp-dev;
     fi
-# Intel MKL
+  # Intel MKL
   - docker exec test apt-get install -qq intel-mkl-64bit-2018.3-051
-# Eigen
+  # Eigen
   - docker exec test apt-get install -qq libeigen3-dev
-# Google Test
-  - docker exec test git clone --depth=1 https://github.com/google/googletest.git
+  # Google Test
+  # Checkout stable release until https://github.com/google/googletest/issues/1865 is fixed.
+  - docker exec test git clone -b release-1.8.1 --depth 1 https://github.com/google/googletest.git
   - docker exec test sh -c "cd googletest && mkdir build && cd build && $CMAKE .. -GNinja && ninja && ninja install"
-# Ceres Solver
+  # Ceres Solver
   - docker exec test apt-get install -qq libgoogle-glog-dev;
   - if [ -n "$(ls $HOME/ceres-solver)" ]; then
       docker cp $HOME/ceres-solver test:/root;
       docker exec test sh -c "cd ceres-solver/build && ninja install";
     else
-      docker exec test git clone --depth=1 https://ceres-solver.googlesource.com/ceres-solver;
+      docker exec test git clone --depth 1 https://ceres-solver.googlesource.com/ceres-solver;
       docker exec test sh -c "cd ceres-solver && mkdir build && cd build && $CMAKE .. -GNinja -DBUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF -DCMAKE_LIBRARY_PATH=/opt/intel/mkl/lib/intel64 -DCXSPARSE=OFF -DEIGENSPARSE=OFF -DGFLAGS=OFF -DSCHUR_SPECIALIZATIONS=OFF -DSUITESPARSE=OFF && ninja && ninja install";
       docker cp test:/root/ceres-solver $HOME;
     fi
-# FLANN
+  # FLANN
   - docker exec test apt-get install -qq libflann-dev
-# Boost
+  # Boost
   - docker exec test wget -nv https://dl.bintray.com/boostorg/release/1.67.0/source/boost_1_67_0.tar.bz2
   - docker exec test tar xjf boost_1_67_0.tar.bz2
   - docker exec test sh -c "cd boost_1_67_0 && ./bootstrap.sh && ./b2 link=shared --with-filesystem --with-program_options --with-serialization --with-system install -d0 -j5 --prefix=."

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,31 +1,27 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.9)
 
-project(polatory CXX)
+project(Polatory CXX)
 
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
-include(polatory_get_boost_dlls)
-include(polatory_target_contents)
+include(polatory_common_functions)
 
 find_package(Boost 1.67.0 REQUIRED)
-find_package(Eigen3 REQUIRED)
 
-option(COVERAGE "Compile with --coverage option" OFF)
+option(USE_PREBUILT_BOOST "Use prebuilt Boost libraries specified manually. This option takes effect only on MSVC.")
 
 if(UNIX)
+    if(NOT CMAKE_CXX_COMPILER_ID MATCHES "^(Clang|GNU)$")
+        message(FATAL_ERROR "Not supported compiler.")
+    endif()
+
     set(MKL_ROOT /opt/intel/mkl CACHE PATH "Path to mkl")
     set(MKL_INCLUDE_DIR "${MKL_ROOT}/include")
     set(MKL_LIB_DIR "${MKL_ROOT}/lib/intel64")
-
-    if(CMAKE_CXX_COMPILER_ID MATCHES "^(Clang|GNU)$")
-        set(CMAKE_CXX_FLAGS "-std=c++14 -fopenmp")
-        set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG")
-        if(COVERAGE)
-            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")
-        endif()
-    else()
+elseif(MSVC)
+    if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
         message(FATAL_ERROR "Not supported compiler.")
     endif()
-elseif(MSVC)
+
     set(_PF86 "ProgramFiles(x86)")
     file(TO_CMAKE_PATH "$ENV{${_PF86}}" _PROG_FILES_X86)
 
@@ -41,9 +37,15 @@ elseif(MSVC)
         set(MKL_LIB_DIR "${MKL_ROOT}/lib/intel64")
     endif()
 
-    set(VCPKG_ROOT "${_VCPKG_INSTALLED_DIR}/x64-windows")
+    set(VCPKG_ROOT "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}")
     set(VCPKG_LIB_DIR "${VCPKG_ROOT}$<$<CONFIG:Debug>:/debug>/lib")
     set(VCPKG_INCLUDE_DIR "${VCPKG_ROOT}/include")
+
+    if(USE_PREBUILT_BOOST)
+        if("${Boost_INCLUDE_DIR}" STREQUAL "${VCPKG_INCLUDE_DIR}")
+            message(FATAL_ERROR "Boost libraries from vcpkg are detected. Turn off USE_PREBUILT_BOOST.")
+        endif()
+    endif()
 
     set(POLATORY_DLLS
         ${MKL_DLL_DIR}/mkl_avx.dll
@@ -55,36 +57,9 @@ elseif(MSVC)
         ${MKL_DLL_DIR}/mkl_mc3.dll
         ${MKL_DLL_DIR}/mkl_sequential.dll
     )
-
-    if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-        set(CMAKE_CXX_FLAGS "/MP /EHsc /std:c++14 /openmp")
-        set(CMAKE_CXX_FLAGS_RELEASE "/MD /O2 /Ob2 /DNDEBUG /GL")
-    else()
-        message(FATAL_ERROR "Not supported compiler.")
-    endif()
-
-    add_definitions(
-        -DBOOST_ALL_DYN_LINK
-        -DBOOST_ALL_NO_LIB
-    )
 else()
     message(FATAL_ERROR "Not supported system.")
 endif()
-
-add_definitions(
-    -DEIGEN_DONT_PARALLELIZE
-    -DEIGEN_MPL2_ONLY
-    -DEIGEN_USE_MKL_ALL
-    -DPOLATORY_FTZ
-)
-
-include_directories(
-    include
-    ${Boost_INCLUDE_DIR}
-    ${EIGEN3_INCLUDE_DIR}
-    ${MKL_INCLUDE_DIR}
-    ${VCPKG_INCLUDE_DIR}
-)
 
 add_subdirectory(benchmark)
 add_subdirectory(examples)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,11 @@
 cmake_minimum_required(VERSION 3.9)
 
+if(NOT CMAKE_BUILD_TYPE)
+    message("-- CMAKE_BUILD_TYPE is not set. Defaulting to Release.")
+endif()
+# Must be set before a toolchain file is loaded by project() command.
+set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Build type: Debug or Release." FORCE)
+
 project(Polatory CXX)
 
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")

--- a/README.md
+++ b/README.md
@@ -172,14 +172,16 @@ Visual Studio 2017
 
 1. Build polatory
 
+    Open **Start** > **Visual Studio 2017** > **x64 Native Tools Command Prompt for VS 2017**.
+
     ```bat
     cd /d %userprofile%
     git clone https://github.com/polatory/polatory.git
     cd polatory
     mkdir build
     cd build
-    cmake .. -G"Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE="Release" -DCMAKE_CONFIGURATION_TYPES="Release" -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows
-    msbuild polatory.sln /m
+    cmake .. -GNinja -DCMAKE_BUILD_TYPE="Release" -DCMAKE_CONFIGURATION_TYPES="Release" -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows
+    ninja
     ```
 
 ## Contribution

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Visual Studio 2017
     cd polatory
     mkdir build
     cd build
-    cmake .. -GNinja -DCMAKE_BUILD_TYPE="Release" -DCMAKE_CONFIGURATION_TYPES="Release" -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows
+    cmake .. -GNinja -DCMAKE_BUILD_TYPE="Release" -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
     ninja
     ```
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Visual Studio 2017
     On Ubuntu 16.04 LTS, CMake >= 3.9 must be installed manually.
 
     ```bash
-    sudo apt install build-essential cmake git
+    sudo apt install build-essential cmake git ninja-build
     ```
     If you use Clang, Intel(R) OpenMP is required.
     ```bash
@@ -99,9 +99,9 @@ Visual Studio 2017
     git clone https://github.com/google/googletest.git
     cd googletest
     mkdir build && cd build
-    cmake ..
-    make -j8
-    sudo make install
+    cmake .. -GNinja
+    ninja
+    sudo ninja install
     ```
 
 1. Install [Ceres Solver](http://ceres-solver.org/)
@@ -112,9 +112,9 @@ Visual Studio 2017
     git clone https://ceres-solver.googlesource.com/ceres-solver
     cd ceres-solver
     mkdir build && cd build/
-    cmake .. -DCMAKE_LIBRARY_PATH=/opt/intel/mkl/lib/intel64 -DGFLAGS=OFF -DLAPACK=ON
-    make -j8
-    sudo make install
+    cmake .. -GNinja -DCMAKE_LIBRARY_PATH=/opt/intel/mkl/lib/intel64 -DGFLAGS=OFF -DLAPACK=ON
+    ninja
+    sudo ninja install
     ```
 
 1. Install [FLANN](http://www.cs.ubc.ca/research/flann/)
@@ -141,8 +141,8 @@ Visual Studio 2017
     git clone https://github.com/polatory/polatory.git
     cd polatory
     mkdir build && cd build
-    cmake .. -DBOOST_ROOT=~/boost_1_67_0 -DCMAKE_BUILD_TYPE=Release
-    make -j8
+    cmake .. -GNinja -DBOOST_ROOT=~/boost_1_67_0
+    ninja
     ```
 
 ### On Windows
@@ -180,7 +180,7 @@ Visual Studio 2017
     cd polatory
     mkdir build
     cd build
-    cmake .. -GNinja -DCMAKE_BUILD_TYPE="Release" -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
+    cmake .. -GNinja -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
     ninja
     ```
 

--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ Visual Studio 2017
     ```bash
     sudo apt install build-essential cmake git ninja-build
     ```
-    If you use Clang, Intel(R) OpenMP is required.
+    If you use Clang, `libomp-dev` is required.
     ```bash
-    sudo apt install clang libiomp-dev
+    sudo apt install clang libomp-dev
     ```
 
 1. Download and install [Intel(R) MKL](https://software.intel.com/mkl).

--- a/README.md
+++ b/README.md
@@ -61,9 +61,11 @@ Visual Studio 2017
 
 ## Building
 
-### On Ubuntu 16.04 LTS
+### On Ubuntu
 
 1. Install build tools
+
+    On Ubuntu 16.04 LTS, CMake >= 3.9 must be installed manually.
 
     ```bash
     sudo apt install build-essential cmake git
@@ -79,8 +81,7 @@ Visual Studio 2017
 
     ```bash
     cd
-    wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB
-    sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB
+    wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB -O - | sudo apt-key add -
     sudo sh -c 'echo deb https://apt.repos.intel.com/mkl all main > /etc/apt/sources.list.d/intel-mkl.list'
     sudo apt update
     sudo apt install intel-mkl-64bit-2018.3-051
@@ -95,12 +96,12 @@ Visual Studio 2017
 1. Install [Google Test](https://github.com/google/googletest)
 
     ```bash
-    sudo apt install libgtest-dev
-    cd
-    mkdir gtest-build; cd gtest-build/
-    cmake /usr/src/gtest/
-    make
-    sudo cp *.a /usr/local/lib/
+    git clone https://github.com/google/googletest.git
+    cd googletest
+    mkdir build && cd build
+    cmake ..
+    make -j8
+    sudo make install
     ```
 
 1. Install [Ceres Solver](http://ceres-solver.org/)
@@ -110,7 +111,7 @@ Visual Studio 2017
     cd
     git clone https://ceres-solver.googlesource.com/ceres-solver
     cd ceres-solver
-    mkdir build; cd build/
+    mkdir build && cd build/
     cmake .. -DCMAKE_LIBRARY_PATH=/opt/intel/mkl/lib/intel64 -DGFLAGS=OFF -DLAPACK=ON
     make -j8
     sudo make install
@@ -127,7 +128,7 @@ Visual Studio 2017
     ```bash
     cd
     wget https://dl.bintray.com/boostorg/release/1.67.0/source/boost_1_67_0.tar.bz2
-    tar xvfj boost_1_67_0.tar.bz2
+    tar xjf boost_1_67_0.tar.bz2
     cd boost_1_67_0
     ./bootstrap.sh
     ./b2 install -j8 --prefix=.
@@ -139,7 +140,7 @@ Visual Studio 2017
     cd
     git clone https://github.com/polatory/polatory.git
     cd polatory
-    mkdir build; cd build
+    mkdir build && cd build
     cmake .. -DBOOST_ROOT=~/boost_1_67_0 -DCMAKE_BUILD_TYPE=Release
     make -j8
     ```
@@ -148,7 +149,7 @@ Visual Studio 2017
 
 1. Install libraries with [vcpkg](https://github.com/Microsoft/vcpkg)
 
-    ```
+    ```bat
     cd /d C:\
     git clone https://github.com/Microsoft/vcpkg.git
     cd vcpkg
@@ -171,13 +172,13 @@ Visual Studio 2017
 
 1. Build polatory
 
-    ```
+    ```bat
     cd /d %userprofile%
     git clone https://github.com/polatory/polatory.git
     cd polatory
     mkdir build
     cd build
-    cmake .. -G"Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE="Release" -DCMAKE_CONFIGURATION_TYPES="Release" -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
+    cmake .. -G"Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE="Release" -DCMAKE_CONFIGURATION_TYPES="Release" -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows
     msbuild polatory.sln /m
     ```
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,7 @@ before_build:
   - mkdir build && cd build
 
 build_script:
-  - cmake .. -GNinja -DCMAKE_BUILD_TYPE="Release" -DCMAKE_CONFIGURATION_TYPES="Release" -DCMAKE_TOOLCHAIN_FILE=%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake -DBOOST_ROOT=C:\Libraries\boost_1_67_0 -DUSE_PREBUILT_BOOST=ON
+  - cmake .. -GNinja -DCMAKE_BUILD_TYPE="Release" -DCMAKE_TOOLCHAIN_FILE=%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake -DBOOST_ROOT=C:\Libraries\boost_1_67_0 -DUSE_PREBUILT_BOOST=ON
   - ninja
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,14 +24,7 @@ cache:
   - C:\Tools\vcpkg\installed
 
 install:
-  # Ninja
-  - appveyor DownloadFile https://github.com/ninja-build/ninja/releases/download/v1.8.2/ninja-win.zip
-  - 7z x ninja-win.zip -oC:\ninja > nul
-  - set PATH=C:\ninja;%PATH%
-  - ninja --version
-  # Intel MKL
   - C:\Miniconda-x64\Scripts\conda install mkl-devel=2018.0 -y -c intel
-  # Other libraries
   - echo set(VCPKG_BUILD_TYPE release) >> %VCPKG_DIR%\triplets\x64-windows.cmake
   - vcpkg install ceres flann eigen3 gtest --triplet x64-windows
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,7 @@ before_build:
   - mkdir build && cd build
 
 build_script:
-  - cmake .. -GNinja -DCMAKE_BUILD_TYPE="Release" -DCMAKE_TOOLCHAIN_FILE=%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake -DBOOST_ROOT=C:\Libraries\boost_1_67_0 -DUSE_PREBUILT_BOOST=ON
+  - cmake .. -GNinja -DCMAKE_TOOLCHAIN_FILE=%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake -DBOOST_ROOT=C:\Libraries\boost_1_67_0 -DUSE_PREBUILT_BOOST=ON
   - ninja
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,19 +24,27 @@ cache:
   - C:\Tools\vcpkg\installed
 
 install:
+  # Ninja
+  - appveyor DownloadFile https://github.com/ninja-build/ninja/releases/download/v1.8.2/ninja-win.zip
+  - 7z x ninja-win.zip -oC:\ninja > nul
+  - set PATH=C:\ninja;%PATH%
+  - ninja --version
+  # Intel MKL
   - C:\Miniconda-x64\Scripts\conda install mkl-devel=2018.0 -y -c intel
+  # Other libraries
   - echo set(VCPKG_BUILD_TYPE release) >> %VCPKG_DIR%\triplets\x64-windows.cmake
   - vcpkg install ceres flann eigen3 gtest --triplet x64-windows
 
 before_build:
+  - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
   - mkdir build && cd build
-  - cmake .. -G"Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE="Release" -DCMAKE_CONFIGURATION_TYPES="Release" -DCMAKE_TOOLCHAIN_FILE=%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake -DBOOST_ROOT=C:\Libraries\boost_1_67_0
 
 build_script:
-  - msbuild polatory.sln /m /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+  - cmake .. -GNinja -DCMAKE_BUILD_TYPE="Release" -DCMAKE_CONFIGURATION_TYPES="Release" -DCMAKE_TOOLCHAIN_FILE=%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake -DBOOST_ROOT=C:\Libraries\boost_1_67_0 -DUSE_PREBUILT_BOOST=ON
+  - ninja
 
 test_script:
-  - test\Release\Unittest.exe
+  - test\Unittest.exe
 
 notifications:
   - provider: Slack

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,9 +1,9 @@
 add_executable(points points.cpp)
-target_link_libraries(points polatory)
+target_link_libraries(points PRIVATE polatory)
 polatory_enable_ipo(points)
 
 add_executable(predict predict.cpp)
-target_link_libraries(predict polatory)
+target_link_libraries(predict PRIVATE polatory)
 polatory_enable_ipo(predict)
 
 if(MSVC)

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,12 +1,13 @@
 add_executable(points points.cpp)
-target_link_libraries(points ${PROJECT_NAME})
+target_link_libraries(points polatory)
+polatory_enable_ipo(points)
 
 add_executable(predict predict.cpp)
-target_link_libraries(predict ${PROJECT_NAME})
+target_link_libraries(predict polatory)
+polatory_enable_ipo(predict)
 
 if(MSVC)
-    polatory_get_boost_dlls(BOOST_DLLS)
-    polatory_target_contents(predict ${POLATORY_DLLS} ${BOOST_DLLS})
+    polatory_target_contents(predict ${POLATORY_DLLS})
 endif()
 
 set(FILES

--- a/cmake/polatory_common_functions.cmake
+++ b/cmake/polatory_common_functions.cmake
@@ -1,0 +1,3 @@
+include(polatory_enable_ipo)
+include(polatory_get_prebuilt_boost_dlls)
+include(polatory_target_contents)

--- a/cmake/polatory_enable_ipo.cmake
+++ b/cmake/polatory_enable_ipo.cmake
@@ -1,0 +1,27 @@
+## # polatory_enable_ipo
+## 
+## Enables interprocedural optimization for the target, if possible.
+function(polatory_enable_ipo TARGET)
+    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+        return()
+    endif()
+
+    if(MSVC)
+        set_property(TARGET ${TARGET} APPEND_STRING PROPERTY
+            COMPILE_FLAGS " /GL "
+        )
+        set_property(TARGET ${TARGET} APPEND_STRING PROPERTY
+            LINK_FLAGS " /LTCG "
+        )
+        message(STATUS "IPO is supported.")
+    else()
+        include(CheckIPOSupported)
+        check_ipo_supported(RESULT ipo_supported OUTPUT output)
+        if(ipo_supported)
+            set_property(TARGET ${TARGET} PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
+            message(STATUS "IPO is supported.")
+        else()
+            message(STATUS "IPO is not supported: ${output}.")
+        endif()
+    endif()
+endfunction()

--- a/cmake/polatory_enable_ipo.cmake
+++ b/cmake/polatory_enable_ipo.cmake
@@ -1,27 +1,26 @@
 ## # polatory_enable_ipo
 ## 
-## Enables interprocedural optimization for the target, if possible.
+## Enables interprocedural optimization for the target.
 function(polatory_enable_ipo TARGET)
     if(CMAKE_BUILD_TYPE STREQUAL "Debug")
         return()
     endif()
 
-    if(MSVC)
-        set_property(TARGET ${TARGET} APPEND_STRING PROPERTY
-            COMPILE_FLAGS " /GL "
-        )
-        set_property(TARGET ${TARGET} APPEND_STRING PROPERTY
-            LINK_FLAGS " /LTCG "
-        )
-        message(STATUS "IPO is supported.")
+    # See https://gitlab.kitware.com/cmake/cmake/merge_requests/1721
+    if(CMAKE_VERSION VERSION_LESS 3.12)
+        if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+            target_compile_options(${TARGET} PRIVATE /GL)
+            target_link_libraries(${TARGET} PRIVATE -LTCG)
+            # NB: This variable also affects other targets in the same directory.
+            set(CMAKE_STATIC_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} /LTCG" PARENT_SCOPE)
+        endif()
     else()
         include(CheckIPOSupported)
         check_ipo_supported(RESULT ipo_supported OUTPUT output)
         if(ipo_supported)
             set_property(TARGET ${TARGET} PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
-            message(STATUS "IPO is supported.")
         else()
-            message(STATUS "IPO is not supported: ${output}.")
+            message(WARNING "${output}")
         endif()
     endif()
 endfunction()

--- a/cmake/polatory_get_prebuilt_boost_dlls.cmake
+++ b/cmake/polatory_get_prebuilt_boost_dlls.cmake
@@ -1,10 +1,8 @@
-## # polatory_get_boost_dlls
+## # polatory_get_prebuilt_boost_dlls
 ## 
 ## Returns paths of DLLs which correspond to ${Boost_LIBRARIES}.
-## If Boost is provided from vcpkg, the result will be empty
-## as vcpkg copies those dlls after build.
-function(polatory_get_boost_dlls BOOST_DLLS)
-    if("${Boost_INCLUDE_DIR}" STREQUAL "${VCPKG_INCLUDE_DIR}")
+function(polatory_get_prebuilt_boost_dlls BOOST_DLLS)
+    if(NOT USE_PREBUILT_BOOST)
         set(${BOOST_DLLS} "" PARENT_SCOPE)
         return()
     endif()

--- a/examples/kriging_cross_validation/CMakeLists.txt
+++ b/examples/kriging_cross_validation/CMakeLists.txt
@@ -6,11 +6,13 @@ file(GLOB_RECURSE SOURCES "*.cpp")
 add_executable(${TARGET} ${SOURCES})
 
 target_link_libraries(${TARGET}
-    ${PROJECT_NAME}
     ${Boost_LIBRARIES}
+    polatory
 )
 
+polatory_enable_ipo(${TARGET})
+
 if(MSVC)
-    polatory_get_boost_dlls(BOOST_DLLS)
+    polatory_get_prebuilt_boost_dlls(BOOST_DLLS)
     polatory_target_contents(${TARGET} ${POLATORY_DLLS} ${BOOST_DLLS})
 endif()

--- a/examples/kriging_cross_validation/CMakeLists.txt
+++ b/examples/kriging_cross_validation/CMakeLists.txt
@@ -5,7 +5,7 @@ set(TARGET kriging_cross_validation)
 file(GLOB_RECURSE SOURCES "*.cpp")
 add_executable(${TARGET} ${SOURCES})
 
-target_link_libraries(${TARGET}
+target_link_libraries(${TARGET} PRIVATE
     ${Boost_LIBRARIES}
     polatory
 )

--- a/examples/kriging_fit/CMakeLists.txt
+++ b/examples/kriging_fit/CMakeLists.txt
@@ -5,7 +5,7 @@ set(TARGET kriging_fit)
 file(GLOB_RECURSE SOURCES "*.cpp")
 add_executable(${TARGET} ${SOURCES})
 
-target_link_libraries(${TARGET}
+target_link_libraries(${TARGET} PRIVATE
     ${Boost_LIBRARIES}
     polatory
 )

--- a/examples/kriging_fit/CMakeLists.txt
+++ b/examples/kriging_fit/CMakeLists.txt
@@ -6,11 +6,13 @@ file(GLOB_RECURSE SOURCES "*.cpp")
 add_executable(${TARGET} ${SOURCES})
 
 target_link_libraries(${TARGET}
-    ${PROJECT_NAME}
     ${Boost_LIBRARIES}
+    polatory
 )
 
+polatory_enable_ipo(${TARGET})
+
 if(MSVC)
-    polatory_get_boost_dlls(BOOST_DLLS)
+    polatory_get_prebuilt_boost_dlls(BOOST_DLLS)
     polatory_target_contents(${TARGET} ${POLATORY_DLLS} ${BOOST_DLLS})
 endif()

--- a/examples/kriging_predict/CMakeLists.txt
+++ b/examples/kriging_predict/CMakeLists.txt
@@ -6,11 +6,13 @@ file(GLOB_RECURSE SOURCES "*.cpp")
 add_executable(${TARGET} ${SOURCES})
 
 target_link_libraries(${TARGET}
-    ${PROJECT_NAME}
     ${Boost_LIBRARIES}
+    polatory
 )
 
+polatory_enable_ipo(${TARGET})
+
 if(MSVC)
-    polatory_get_boost_dlls(BOOST_DLLS)
+    polatory_get_prebuilt_boost_dlls(BOOST_DLLS)
     polatory_target_contents(${TARGET} ${POLATORY_DLLS} ${BOOST_DLLS})
 endif()

--- a/examples/kriging_predict/CMakeLists.txt
+++ b/examples/kriging_predict/CMakeLists.txt
@@ -5,7 +5,7 @@ set(TARGET kriging_predict)
 file(GLOB_RECURSE SOURCES "*.cpp")
 add_executable(${TARGET} ${SOURCES})
 
-target_link_libraries(${TARGET}
+target_link_libraries(${TARGET} PRIVATE
     ${Boost_LIBRARIES}
     polatory
 )

--- a/examples/kriging_variogram/CMakeLists.txt
+++ b/examples/kriging_variogram/CMakeLists.txt
@@ -6,11 +6,13 @@ file(GLOB_RECURSE SOURCES "*.cpp")
 add_executable(${TARGET} ${SOURCES})
 
 target_link_libraries(${TARGET}
-    ${PROJECT_NAME}
     ${Boost_LIBRARIES}
+    polatory
 )
 
+polatory_enable_ipo(${TARGET})
+
 if(MSVC)
-    polatory_get_boost_dlls(BOOST_DLLS)
+    polatory_get_prebuilt_boost_dlls(BOOST_DLLS)
     polatory_target_contents(${TARGET} ${POLATORY_DLLS} ${BOOST_DLLS})
 endif()

--- a/examples/kriging_variogram/CMakeLists.txt
+++ b/examples/kriging_variogram/CMakeLists.txt
@@ -5,7 +5,7 @@ set(TARGET kriging_variogram)
 file(GLOB_RECURSE SOURCES "*.cpp")
 add_executable(${TARGET} ${SOURCES})
 
-target_link_libraries(${TARGET}
+target_link_libraries(${TARGET} PRIVATE
     ${Boost_LIBRARIES}
     polatory
 )

--- a/examples/point_cloud/CMakeLists.txt
+++ b/examples/point_cloud/CMakeLists.txt
@@ -6,11 +6,13 @@ file(GLOB_RECURSE SOURCES "*.cpp")
 add_executable(${TARGET} ${SOURCES})
 
 target_link_libraries(${TARGET}
-    ${PROJECT_NAME}
     ${Boost_LIBRARIES}
+    polatory
 )
 
+polatory_enable_ipo(${TARGET})
+
 if(MSVC)
-    polatory_get_boost_dlls(BOOST_DLLS)
+    polatory_get_prebuilt_boost_dlls(BOOST_DLLS)
     polatory_target_contents(${TARGET} ${POLATORY_DLLS} ${BOOST_DLLS})
 endif()

--- a/examples/point_cloud/CMakeLists.txt
+++ b/examples/point_cloud/CMakeLists.txt
@@ -5,7 +5,7 @@ set(TARGET point_cloud)
 file(GLOB_RECURSE SOURCES "*.cpp")
 add_executable(${TARGET} ${SOURCES})
 
-target_link_libraries(${TARGET}
+target_link_libraries(${TARGET} PRIVATE
     ${Boost_LIBRARIES}
     polatory
 )

--- a/examples/terrain_25d/CMakeLists.txt
+++ b/examples/terrain_25d/CMakeLists.txt
@@ -5,7 +5,7 @@ set(TARGET terrain_25d)
 file(GLOB_RECURSE SOURCES "*.cpp")
 add_executable(${TARGET} ${SOURCES})
 
-target_link_libraries(${TARGET}
+target_link_libraries(${TARGET} PRIVATE
     ${Boost_LIBRARIES}
     polatory
 )

--- a/examples/terrain_25d/CMakeLists.txt
+++ b/examples/terrain_25d/CMakeLists.txt
@@ -6,11 +6,13 @@ file(GLOB_RECURSE SOURCES "*.cpp")
 add_executable(${TARGET} ${SOURCES})
 
 target_link_libraries(${TARGET}
-    ${PROJECT_NAME}
     ${Boost_LIBRARIES}
+    polatory
 )
 
+polatory_enable_ipo(${TARGET})
+
 if(MSVC)
-    polatory_get_boost_dlls(BOOST_DLLS)
+    polatory_get_prebuilt_boost_dlls(BOOST_DLLS)
     polatory_target_contents(${TARGET} ${POLATORY_DLLS} ${BOOST_DLLS})
 endif()

--- a/examples/terrain_3d/CMakeLists.txt
+++ b/examples/terrain_3d/CMakeLists.txt
@@ -5,7 +5,7 @@ set(TARGET terrain_3d)
 file(GLOB_RECURSE SOURCES "*.cpp")
 add_executable(${TARGET} ${SOURCES})
 
-target_link_libraries(${TARGET}
+target_link_libraries(${TARGET} PRIVATE
     ${Boost_LIBRARIES}
     polatory
 )

--- a/examples/terrain_3d/CMakeLists.txt
+++ b/examples/terrain_3d/CMakeLists.txt
@@ -6,11 +6,13 @@ file(GLOB_RECURSE SOURCES "*.cpp")
 add_executable(${TARGET} ${SOURCES})
 
 target_link_libraries(${TARGET}
-    ${PROJECT_NAME}
     ${Boost_LIBRARIES}
+    polatory
 )
 
+polatory_enable_ipo(${TARGET})
+
 if(MSVC)
-    polatory_get_boost_dlls(BOOST_DLLS)
+    polatory_get_prebuilt_boost_dlls(BOOST_DLLS)
     polatory_target_contents(${TARGET} ${POLATORY_DLLS} ${BOOST_DLLS})
 endif()

--- a/examples/terrain_inequality/CMakeLists.txt
+++ b/examples/terrain_inequality/CMakeLists.txt
@@ -6,11 +6,13 @@ file(GLOB_RECURSE SOURCES "*.cpp")
 add_executable(${TARGET} ${SOURCES})
 
 target_link_libraries(${TARGET}
-    ${PROJECT_NAME}
     ${Boost_LIBRARIES}
+    polatory
 )
 
+polatory_enable_ipo(${TARGET})
+
 if(MSVC)
-    polatory_get_boost_dlls(BOOST_DLLS)
+    polatory_get_prebuilt_boost_dlls(BOOST_DLLS)
     polatory_target_contents(${TARGET} ${POLATORY_DLLS} ${BOOST_DLLS})
 endif()

--- a/examples/terrain_inequality/CMakeLists.txt
+++ b/examples/terrain_inequality/CMakeLists.txt
@@ -5,7 +5,7 @@ set(TARGET terrain_inequality)
 file(GLOB_RECURSE SOURCES "*.cpp")
 add_executable(${TARGET} ${SOURCES})
 
-target_link_libraries(${TARGET}
+target_link_libraries(${TARGET} PRIVATE
     ${Boost_LIBRARIES}
     polatory
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,7 +23,7 @@ target_compile_definitions(${TARGET} PUBLIC
     -DPOLATORY_FTZ
 )
 
-if("$ENV{APPVEYOR}" STREQUAL "True")
+if(USE_PREBUILT_BOOST)
     target_compile_definitions(${TARGET} PUBLIC
         -DBOOST_ALL_DYN_LINK
         -DBOOST_ALL_NO_LIB
@@ -39,14 +39,14 @@ target_include_directories(${TARGET} PUBLIC
 )
 
 if(UNIX)
-    target_link_libraries(${TARGET}
+    target_link_libraries(${TARGET} INTERFACE
         "-Wl,--start-group"
         ${MKL_LIB_DIR}/libmkl_intel_lp64.a ${MKL_LIB_DIR}/libmkl_sequential.a ${MKL_LIB_DIR}/libmkl_core.a pthread m dl
         ceres flann_cpp glog
         "-Wl,--end-group"
     )
 elseif(MSVC)
-    target_link_libraries(${TARGET}
+    target_link_libraries(${TARGET} INTERFACE
         ${MKL_LIB_DIR}/mkl_intel_lp64_dll.lib ${MKL_LIB_DIR}/mkl_sequential_dll.lib ${MKL_LIB_DIR}/mkl_core_dll.lib
         debug ${VCPKG_LIB_DIR}/ceres-debug.lib optimized ${VCPKG_LIB_DIR}/ceres.lib
         debug ${VCPKG_LIB_DIR}/flann_cpp-gd.lib optimized ${VCPKG_LIB_DIR}/flann_cpp.lib
@@ -54,10 +54,12 @@ elseif(MSVC)
     )
 endif()
 
-target_link_libraries(${TARGET}
+target_link_libraries(${TARGET} INTERFACE
     ${Boost_LIBRARIES}
     ${OpenMP_CXX_LIBRARIES}
 )
+
+polatory_enable_ipo(${TARGET})
 
 if(MSVC)
     polatory_get_prebuilt_boost_dlls(BOOST_DLLS)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,9 +1,42 @@
 find_package(Boost 1.67.0 COMPONENTS serialization REQUIRED)
+find_package(Eigen3 REQUIRED)
+find_package(OpenMP REQUIRED)
 
 set(TARGET polatory)
 
 file(GLOB_RECURSE SOURCES "*.cpp")
 add_library(${TARGET} STATIC ${SOURCES})
+
+if(UNIX)
+    target_compile_options(${TARGET} PUBLIC -std=c++14 ${OpenMP_CXX_FLAGS})
+    if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+        target_compile_options(${TARGET} PUBLIC -O2)
+    endif()
+elseif(MSVC)
+    target_compile_options(${TARGET} PUBLIC /std:c++14 ${OpenMP_CXX_FLAGS})
+endif()
+
+target_compile_definitions(${TARGET} PUBLIC
+    -DEIGEN_DONT_PARALLELIZE
+    -DEIGEN_MPL2_ONLY
+    -DEIGEN_USE_MKL_ALL
+    -DPOLATORY_FTZ
+)
+
+if("$ENV{APPVEYOR}" STREQUAL "True")
+    target_compile_definitions(${TARGET} PUBLIC
+        -DBOOST_ALL_DYN_LINK
+        -DBOOST_ALL_NO_LIB
+    )
+endif()
+
+target_include_directories(${TARGET} PUBLIC
+    ${PROJECT_SOURCE_DIR}/include
+    ${Boost_INCLUDE_DIR}
+    ${EIGEN3_INCLUDE_DIR}
+    ${MKL_INCLUDE_DIR}
+    ${VCPKG_INCLUDE_DIR}
+)
 
 if(UNIX)
     target_link_libraries(${TARGET}
@@ -23,10 +56,11 @@ endif()
 
 target_link_libraries(${TARGET}
     ${Boost_LIBRARIES}
+    ${OpenMP_CXX_LIBRARIES}
 )
 
 if(MSVC)
-    polatory_get_boost_dlls(BOOST_DLLS)
+    polatory_get_prebuilt_boost_dlls(BOOST_DLLS)
     list(APPEND POLATORY_DLLS ${BOOST_DLLS})
     set(POLATORY_DLLS ${POLATORY_DLLS} PARENT_SCOPE)
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 find_package(Boost 1.67.0 COMPONENTS filesystem system REQUIRED)
+find_package(GTest REQUIRED)
 
 set(TARGET Unittest)
 
@@ -6,23 +7,19 @@ file(GLOB_RECURSE SOURCES "*.cpp")
 add_executable(${TARGET} ${SOURCES})
 
 if(UNIX)
-    target_link_libraries(${TARGET}
-        ${PROJECT_NAME}
-        gtest pthread
-    )
+    target_link_libraries(${TARGET} pthread)
 elseif(MSVC)
-    target_link_libraries(${TARGET}
-        ${PROJECT_NAME}
-        debug ${VCPKG_LIB_DIR}/manual-link/gtestd.lib optimized ${VCPKG_LIB_DIR}/manual-link/gtest.lib
-    )
-
-    polatory_get_boost_dlls(BOOST_DLLS)
+    polatory_get_prebuilt_boost_dlls(BOOST_DLLS)
     polatory_target_contents(${TARGET} ${POLATORY_DLLS} ${BOOST_DLLS})
 endif()
 
 target_link_libraries(${TARGET}
     ${Boost_LIBRARIES}
+    GTest::GTest
+    polatory
 )
+
+polatory_enable_ipo(${TARGET})
 
 add_test(
     NAME ${TARGET}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,20 +6,18 @@ set(TARGET Unittest)
 file(GLOB_RECURSE SOURCES "*.cpp")
 add_executable(${TARGET} ${SOURCES})
 
-if(UNIX)
-    target_link_libraries(${TARGET} pthread)
-elseif(MSVC)
-    polatory_get_prebuilt_boost_dlls(BOOST_DLLS)
-    polatory_target_contents(${TARGET} ${POLATORY_DLLS} ${BOOST_DLLS})
-endif()
-
-target_link_libraries(${TARGET}
+target_link_libraries(${TARGET} PRIVATE
     ${Boost_LIBRARIES}
     GTest::GTest
     polatory
 )
 
 polatory_enable_ipo(${TARGET})
+
+if(MSVC)
+    polatory_get_prebuilt_boost_dlls(BOOST_DLLS)
+    polatory_target_contents(${TARGET} ${POLATORY_DLLS} ${BOOST_DLLS})
+endif()
 
 add_test(
     NAME ${TARGET}


### PR DESCRIPTION
## Tasks

- [x] IPO support for MSVC is added in CMake v3.12 while VS ships v3.11. We need a workaround.
    - https://github.com/Kitware/CMake/commit/a18147e93328af6754a44c72c563436efe358f42#diff-f6bf22aad583868883d6f59604cd805a
    - https://gitlab.kitware.com/cmake/cmake/issues/18189
    - https://visualstudio.uservoice.com/forums/121579-visual-studio-ide/suggestions/35057761-update-the-bundled-cmake-to-version-3-12
- [x] https://github.com/google/googletest/issues/1865
    - Use stable version.