### PR TITLE
Fix bugs around affine transformation.

### DIFF
--- a/include/polatory/geometry/affine_transformation3d.hpp
+++ b/include/polatory/geometry/affine_transformation3d.hpp
@@ -23,11 +23,15 @@ public:
 
   const Eigen::Matrix4d& matrix() const;
 
+  bool operator==(const affine_transformation3d& rhs) const;
+
+  bool operator!=(const affine_transformation3d& rhs) const;
+
+  affine_transformation3d operator*(const affine_transformation3d& rhs) const;
+
   point3d transform_point(const point3d& p) const;
 
   vector3d transform_vector(const vector3d& v) const;
-
-  affine_transformation3d operator*(const affine_transformation3d& rhs) const;
 
   static affine_transformation3d roll_pitch_yaw(const vector3d& angles, const std::array<int, 3>& axes = { 2, 1, 0 });
 

--- a/include/polatory/rbf/biharmonic2d.hpp
+++ b/include/polatory/rbf/biharmonic2d.hpp
@@ -21,7 +21,7 @@ public:
   }
 
   std::unique_ptr<rbf_base> clone() const override {
-    return std::make_unique<biharmonic2d>(parameters());
+    return std::make_unique<biharmonic2d>(*this);
   }
 
   int cpd_order() const override {

--- a/include/polatory/rbf/biharmonic3d.hpp
+++ b/include/polatory/rbf/biharmonic3d.hpp
@@ -20,7 +20,7 @@ public:
   }
 
   std::unique_ptr<rbf_base> clone() const override {
-    return std::make_unique<biharmonic3d>(parameters());
+    return std::make_unique<biharmonic3d>(*this);
   }
 
   int cpd_order() const override {

--- a/include/polatory/rbf/cov_exponential.hpp
+++ b/include/polatory/rbf/cov_exponential.hpp
@@ -20,7 +20,7 @@ public:
   }
 
   std::unique_ptr<rbf_base> clone() const override {
-    return std::make_unique<cov_exponential>(parameters());
+    return std::make_unique<cov_exponential>(*this);
   }
 
   static double evaluate_untransformed(double r, const double *params) {

--- a/include/polatory/rbf/cov_quasi_spherical3.hpp
+++ b/include/polatory/rbf/cov_quasi_spherical3.hpp
@@ -20,7 +20,7 @@ public:
   }
 
   std::unique_ptr<rbf_base> clone() const override {
-    return std::make_unique<cov_quasi_spherical3>(parameters());
+    return std::make_unique<cov_quasi_spherical3>(*this);
   }
 
   static double evaluate_untransformed(double r, const double *params) {

--- a/include/polatory/rbf/cov_quasi_spherical5.hpp
+++ b/include/polatory/rbf/cov_quasi_spherical5.hpp
@@ -20,7 +20,7 @@ public:
   }
 
   std::unique_ptr<rbf_base> clone() const override {
-    return std::make_unique<cov_quasi_spherical5>(parameters());
+    return std::make_unique<cov_quasi_spherical5>(*this);
   }
 
   static double evaluate_untransformed(double r, const double *params) {

--- a/include/polatory/rbf/cov_quasi_spherical7.hpp
+++ b/include/polatory/rbf/cov_quasi_spherical7.hpp
@@ -20,7 +20,7 @@ public:
   }
 
   std::unique_ptr<rbf_base> clone() const override {
-    return std::make_unique<cov_quasi_spherical7>(parameters());
+    return std::make_unique<cov_quasi_spherical7>(*this);
   }
 
   static double evaluate_untransformed(double r, const double *params) {

--- a/include/polatory/rbf/cov_quasi_spherical9.hpp
+++ b/include/polatory/rbf/cov_quasi_spherical9.hpp
@@ -20,7 +20,7 @@ public:
   }
 
   std::unique_ptr<rbf_base> clone() const override {
-    return std::make_unique<cov_quasi_spherical9>(parameters());
+    return std::make_unique<cov_quasi_spherical9>(*this);
   }
 
   static double evaluate_untransformed(double r, const double *params) {

--- a/include/polatory/rbf/rbf_base.hpp
+++ b/include/polatory/rbf/rbf_base.hpp
@@ -17,7 +17,6 @@ class rbf_base {
 public:
   virtual ~rbf_base() = default;
 
-  rbf_base(const rbf_base&) = delete;
   rbf_base(rbf_base&&) = delete;
   rbf_base& operator=(const rbf_base&) = delete;
   rbf_base& operator=(rbf_base&&) = delete;
@@ -70,6 +69,7 @@ public:
 
 protected:
   rbf_base() = default;
+  rbf_base(const rbf_base&) = default;
 
 private:
   std::vector<double> params_;

--- a/include/polatory/rbf/reference/cov_gaussian.hpp
+++ b/include/polatory/rbf/reference/cov_gaussian.hpp
@@ -21,7 +21,7 @@ public:
   }
 
   std::unique_ptr<rbf_base> clone() const override {
-    return std::make_unique<cov_gaussian>(parameters());
+    return std::make_unique<cov_gaussian>(*this);
   }
 
   static double evaluate_untransformed(double r, const double *params) {

--- a/include/polatory/rbf/reference/cov_spherical.hpp
+++ b/include/polatory/rbf/reference/cov_spherical.hpp
@@ -21,7 +21,7 @@ public:
   }
 
   std::unique_ptr<rbf_base> clone() const override {
-    return std::make_unique<cov_spherical>(parameters());
+    return std::make_unique<cov_spherical>(*this);
   }
 
   static double evaluate_untransformed(double r, const double *params) {

--- a/include/polatory/rbf/reference/triharmonic3d.hpp
+++ b/include/polatory/rbf/reference/triharmonic3d.hpp
@@ -21,7 +21,7 @@ public:
   }
 
   std::unique_ptr<rbf_base> clone() const override {
-    return std::make_unique<triharmonic3d>(parameters());
+    return std::make_unique<triharmonic3d>(*this);
   }
 
   int cpd_order() const override {

--- a/src/geometry/affine_transformation3d.cpp
+++ b/src/geometry/affine_transformation3d.cpp
@@ -56,7 +56,7 @@ affine_transformation3d affine_transformation3d::roll_pitch_yaw(const vector3d& 
 }
 
 affine_transformation3d affine_transformation3d::scaling(const vector3d& scales) {
-  Eigen::Matrix4d m = Eigen::Matrix4d::Zero();
+  Eigen::Matrix4d m = Eigen::Matrix4d::Identity();
 
   m.diagonal() << scales(0), scales(1), scales(2), 1.0;
 
@@ -64,7 +64,7 @@ affine_transformation3d affine_transformation3d::scaling(const vector3d& scales)
 }
 
 affine_transformation3d affine_transformation3d::translation(const vector3d& shifts) {
-  Eigen::Matrix4d m = Eigen::Matrix4d::Zero();
+  Eigen::Matrix4d m = Eigen::Matrix4d::Identity();
 
   m.col(3) << shifts(0), shifts(1), shifts(2), 1.0;
 

--- a/src/geometry/affine_transformation3d.cpp
+++ b/src/geometry/affine_transformation3d.cpp
@@ -36,16 +36,24 @@ const Eigen::Matrix4d& affine_transformation3d::matrix() const {
   return m_;
 }
 
+bool affine_transformation3d::operator==(const affine_transformation3d& rhs) const {
+  return m_ == rhs.m_;
+}
+
+bool affine_transformation3d::operator!=(const affine_transformation3d& rhs) const {
+  return !(*this == rhs);
+}
+
+affine_transformation3d affine_transformation3d::operator*(const affine_transformation3d& rhs) const {
+  return affine_transformation3d(m_ * rhs.m_);
+}
+
 point3d affine_transformation3d::transform_point(const point3d& p) const {
   return m_.topLeftCorner(3, 4) * p.homogeneous().transpose();
 }
 
 vector3d affine_transformation3d::transform_vector(const vector3d& v) const {
   return m_.topLeftCorner(3, 3) * v.transpose();
-}
-
-affine_transformation3d affine_transformation3d::operator*(const affine_transformation3d& rhs) const {
-  return affine_transformation3d(m_ * rhs.m_);
 }
 
 affine_transformation3d affine_transformation3d::roll_pitch_yaw(const vector3d& angles, const std::array<int, 3>& axes) {

--- a/test/geometry/test_affine_transformation3d.cpp
+++ b/test/geometry/test_affine_transformation3d.cpp
@@ -90,9 +90,9 @@ TEST(affine_transformation3d, translation) {
 
   Eigen::Matrix4d m;
   m <<
-    0.0, 0.0, 0.0, 3.0,
-    0.0, 0.0, 0.0, 5.0,
-    0.0, 0.0, 0.0, 7.0,
+    1.0, 0.0, 0.0, 3.0,
+    0.0, 1.0, 0.0, 5.0,
+    0.0, 0.0, 1.0, 7.0,
     0.0, 0.0, 0.0, 1.0;
 
   EXPECT_EQ(0.0, (m - m_actual).lpNorm<Eigen::Infinity>());

--- a/test/interpolation/random_transformation.hpp
+++ b/test/interpolation/random_transformation.hpp
@@ -15,9 +15,11 @@ polatory::geometry::affine_transformation3d random_transformation(seed_type seed
   std::mt19937 gen(seed);
   std::uniform_real_distribution<> angle_dist(0.0, 2.0 * polatory::common::pi<double>());
   std::uniform_real_distribution<> log_scale_dist(std::log10(0.1), std::log10(10.0));
+  std::uniform_real_distribution<> log_trans_dist(std::log10(1.0), std::log10(1e5));
 
   auto r = polatory::geometry::affine_transformation3d::roll_pitch_yaw({ angle_dist(gen), angle_dist(gen), angle_dist(gen) });
   auto s = polatory::geometry::affine_transformation3d::scaling({ std::pow(10.0, log_scale_dist(gen)), std::pow(10.0, log_scale_dist(gen)), std::pow(10.0, log_scale_dist(gen)) });
+  auto t = polatory::geometry::affine_transformation3d::translation({ std::pow(10.0, log_trans_dist(gen)), std::pow(10.0, log_trans_dist(gen)), std::pow(10.0, log_trans_dist(gen)) });
 
-  return r * s;
+  return t * r * s;
 }

--- a/test/interpolation/random_transformation.hpp
+++ b/test/interpolation/random_transformation.hpp
@@ -15,11 +15,9 @@ polatory::geometry::affine_transformation3d random_transformation(seed_type seed
   std::mt19937 gen(seed);
   std::uniform_real_distribution<> angle_dist(0.0, 2.0 * polatory::common::pi<double>());
   std::uniform_real_distribution<> log_scale_dist(std::log10(0.1), std::log10(10.0));
-  std::uniform_real_distribution<> log_trans_dist(std::log10(1.0), std::log10(1e5));
 
   auto r = polatory::geometry::affine_transformation3d::roll_pitch_yaw({ angle_dist(gen), angle_dist(gen), angle_dist(gen) });
   auto s = polatory::geometry::affine_transformation3d::scaling({ std::pow(10.0, log_scale_dist(gen)), std::pow(10.0, log_scale_dist(gen)), std::pow(10.0, log_scale_dist(gen)) });
-  auto t = polatory::geometry::affine_transformation3d::translation({ std::pow(10.0, log_trans_dist(gen)), std::pow(10.0, log_trans_dist(gen)), std::pow(10.0, log_trans_dist(gen)) });
 
-  return t * r * s;
+  return r * s;
 }

--- a/test/interpolation/test_rbf_evaluator.cpp
+++ b/test/interpolation/test_rbf_evaluator.cpp
@@ -23,7 +23,7 @@ using polatory::rbf::cov_exponential;
 namespace {
 
 void test_poly_degree(int poly_degree, size_t n_points, size_t n_eval_points) {
-  double absolute_tolerance = 1e-6;
+  double absolute_tolerance = 2e-6;
 
   cov_exponential rbf({ 1.0, 0.2 });
   rbf.set_transformation(random_transformation());

--- a/test/interpolation/test_rbf_symmetric_evaluator.cpp
+++ b/test/interpolation/test_rbf_symmetric_evaluator.cpp
@@ -26,7 +26,7 @@ namespace {
 
 template <class Evaluator>
 void test_poly_degree(int poly_degree, size_t n_points, size_t n_eval_points) {
-  double absolute_tolerance = 1e-6;
+  double absolute_tolerance = 2e-6;
 
   cov_exponential rbf({ 1.0, 0.2 });
   rbf.set_transformation(random_transformation());

--- a/test/rbf/test_rbf.cpp
+++ b/test/rbf/test_rbf.cpp
@@ -5,6 +5,7 @@
 
 #include <gtest/gtest.h>
 
+#include <polatory/geometry/affine_transformation3d.hpp>
 #include <polatory/rbf/biharmonic2d.hpp>
 #include <polatory/rbf/biharmonic3d.hpp>
 #include <polatory/rbf/cov_exponential.hpp>
@@ -17,6 +18,7 @@
 #include <polatory/rbf/reference/cov_spherical.hpp>
 #include <polatory/rbf/reference/triharmonic3d.hpp>
 
+using polatory::geometry::affine_transformation3d;
 using polatory::rbf::biharmonic2d;
 using polatory::rbf::biharmonic3d;
 using polatory::rbf::cov_exponential;
@@ -33,6 +35,17 @@ namespace {
 
 double hypot(double x, double y, double z) {
   return std::sqrt(x * x + y * y + z * z);
+}
+
+template <class T>
+void test_clone(const std::vector<double>& params) {
+  T rbf(params);
+  rbf.set_transformation(affine_transformation3d::scaling({ 1.0, 2.0, 3.0 }));
+
+  auto cloned = rbf.clone();
+
+  ASSERT_EQ(rbf.parameters(), cloned->parameters());
+  ASSERT_EQ(rbf.transformation(), cloned->transformation());
 }
 
 void test_gradient(const rbf_base& rbf) {
@@ -73,6 +86,20 @@ void test_gradient(const rbf_base& rbf) {
 }
 
 }  // namespace
+
+TEST(rbf, clone) {
+  test_clone<biharmonic2d>({ 1.0 });
+  test_clone<biharmonic3d>({ 1.0 });
+  test_clone<cov_exponential>({ 1.0, 1.0 });
+  test_clone<cov_quasi_spherical3>({ 1.0, 1.0 });
+  test_clone<cov_quasi_spherical5>({ 1.0, 1.0 });
+  test_clone<cov_quasi_spherical7>({ 1.0, 1.0 });
+  test_clone<cov_quasi_spherical9>({ 1.0, 1.0 });
+
+  test_clone<cov_gaussian>({ 1.0, 1.0 });
+  test_clone<cov_spherical>({ 1.0, 1.0 });
+  test_clone<triharmonic3d>({ 1.0 });
+}
 
 TEST(rbf, gradient) {
   test_gradient(biharmonic2d({ 1.0 }));


### PR DESCRIPTION
This bug was introduced in #54.

Resolves #60.

## Changes

- Fix `rbf_base::clone()` to copy the transformation
- Fix `affine_transformation3d::translation(const vector3d&)`
